### PR TITLE
wip: enable react-intl framework

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -114,6 +114,7 @@
     "react-draggable": "4.x",
     "react-helmet": "^5.2.1",
     "react-jsonschema-form": "1.7.0",
+    "react-intl": "^4.4.0",
     "react-lazyload": "^2.6.2",
     "react-linkify": "^0.2.2",
     "react-measure": "^2.2.6",

--- a/frontend/packages/console-shared/src/components/dashboard/details-card/DetailItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/details-card/DetailItem.tsx
@@ -23,7 +23,7 @@ export const DetailItem: React.FC<DetailItemProps> = React.memo(
 export default DetailItem;
 
 type DetailItemProps = {
-  title: string;
+  title: string | any;
   children: React.ReactNode;
   isLoading?: boolean;
   error?: boolean;

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -20,6 +20,7 @@ import * as UIActions from '../actions/ui';
 import { fetchSwagger, getCachedResources, referenceForModel } from '../module/k8s';
 import { receivedResources, watchAPIServices } from '../actions/k8s';
 import { ClusterVersionModel } from '../models';
+import I18nWrapper from './i18n-wrapper';
 import '../vendor.scss';
 import '../style.scss';
 
@@ -225,13 +226,15 @@ if ('serviceWorker' in navigator) {
 }
 
 render(
-  <Provider store={store}>
-    <Router history={history} basename={window.SERVER_FLAGS.basePath}>
-      <Switch>
-        <Route path="/terminal" component={CloudShellTab} />
-        <Route path="/" component={App} />
-      </Switch>
-    </Router>
-  </Provider>,
+  <I18nWrapper>
+    <Provider store={store}>
+      <Router history={history} basename={window.SERVER_FLAGS.basePath}>
+        <Switch>
+          <Route path="/terminal" component={CloudShellTab} />
+          <Route path="/" component={App} />
+        </Switch>
+      </Router>
+    </Provider>
+  </I18nWrapper>,
   document.getElementById('app'),
 );

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Button } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 import { ArrowCircleUpIcon, InProgressIcon } from '@patternfly/react-icons';
 import { FLAGS, getInfrastructureAPIURL, getInfrastructurePlatform } from '@console/shared';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
@@ -129,7 +130,9 @@ export const DetailsCard_ = connect(mapStateToProps)(
     return (
       <DashboardCard data-test-id="details-card">
         <DashboardCardHeader>
-          <DashboardCardTitle>Details</DashboardCardTitle>
+          <DashboardCardTitle>
+            <FormattedMessage id="app.cluster.card.title" defaultMessage="Details" />
+          </DashboardCardTitle>
           <DashboardCardLink to="/settings/cluster/">View settings</DashboardCardLink>
         </DashboardCardHeader>
         <DashboardCardBody isLoading={flagPending(openshiftFlag)}>
@@ -137,7 +140,8 @@ export const DetailsCard_ = connect(mapStateToProps)(
             {openshiftFlag ? (
               <>
                 <DetailItem
-                  title="Cluster API address"
+                  // title="Cluster API address"
+                  title={<FormattedMessage id="app.cluster.api.address" defaultMessage="Cluster API address" />}
                   isLoading={!infrastructureLoaded}
                   error={!!infrastructureError || (infrastructure && !infrastuctureApiUrl)}
                   valueClassName="co-select-to-copy"
@@ -145,7 +149,8 @@ export const DetailsCard_ = connect(mapStateToProps)(
                   {infrastuctureApiUrl}
                 </DetailItem>
                 <DetailItem
-                  title="Cluster ID"
+                  // title="Cluster ID"
+                  title={<FormattedMessage id="app.cluster.id" defaultMessage="Cluster ID" />}
                   error={!!clusterVersionError || (clusterVersionLoaded && !clusterId)}
                   isLoading={!clusterVersionLoaded}
                 >
@@ -156,7 +161,8 @@ export const DetailsCard_ = connect(mapStateToProps)(
                     )}
                 </DetailItem>
                 <DetailItem
-                  title="Provider"
+                  // title="Provider"
+                  title={<FormattedMessage id="app.cluster.provider" defaultMessage="Provider" />}
                   error={!!infrastructureError || (infrastructure && !infrastructurePlatform)}
                   isLoading={!infrastructureLoaded}
                   valueClassName="co-select-to-copy"
@@ -164,14 +170,16 @@ export const DetailsCard_ = connect(mapStateToProps)(
                   {infrastructurePlatform}
                 </DetailItem>
                 <DetailItem
-                  title="OpenShift version"
+                  // title="OpenShift version"
+                  title={<FormattedMessage id="app.version" defaultMessage="OpenShift version" />}
                   error={!!clusterVersionError || (clusterVersionLoaded && !openShiftVersion)}
                   isLoading={!clusterVersionLoaded}
                 >
                   <ClusterVersion cv={clusterVersionData} />
                 </DetailItem>
                 <DetailItem
-                  title="Update channel"
+                  // title="Update channel"
+                  title={<FormattedMessage id="app.update.channel" defaultMessage="Update channel" />}
                   isLoading={!clusterVersionLoaded && !clusterVersionError}
                   error={!!clusterVersionError || (clusterVersionLoaded && !cvChannel)}
                   valueClassName="co-select-to-copy"

--- a/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
@@ -19,6 +19,8 @@ import {
   isDashboardsTab,
 } from '@console/plugin-sdk';
 import { RootState } from '../../../redux';
+import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
+import { I18nContext } from '../../i18n-wrapper';
 
 const getCardsOnPosition = (cards: DashboardsCard[], position: GridPosition): GridDashboardCard[] =>
   cards
@@ -68,6 +70,8 @@ const DashboardsPage_: React.FC<DashboardsPageProps> = ({ match, kindsInFlight, 
     [pluginPages],
   );
 
+  const context = React.useContext<any>(I18nContext);
+
   return kindsInFlight && k8sModels.size === 0 ? (
     <LoadingBox />
   ) : (
@@ -75,7 +79,20 @@ const DashboardsPage_: React.FC<DashboardsPageProps> = ({ match, kindsInFlight, 
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <PageHeading title={title} detail={true} />
+      <Flex>
+        <FlexItem breakpointMods={[{modifier: FlexModifiers.grow}]}>
+          <PageHeading title={title} detail={true} />
+        </FlexItem>
+        <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-sm"]}]}>
+          <select onChange={context.selectLang}
+            className="pull-right pf-c-select pf-m-expanded"
+            value={context.locale}>
+            <option value="en-US">English</option>
+            <option value="it-IT">Italian</option>
+            <option value="ja-JP">Japanese</option>
+          </select>
+        </FlexItem>
+      </Flex>
       <HorizontalNav match={match} pages={allPages} noStatusBox />
     </>
   );

--- a/frontend/public/components/i18n-wrapper.jsx
+++ b/frontend/public/components/i18n-wrapper.jsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { IntlProvider } from 'react-intl';
+import * as Japanese from "../locales/ja-JP.json";
+import * as Italian from "../locales/it-IT.json";
+import * as English from "../locales/en-US.json";
+
+export const I18nContext = React.createContext();
+
+const navLang = navigator.language;
+let lang;
+
+if (navLang === "ja-JP") {
+    lang = Japanese;
+} else if (navLang === "it-IT") {
+    lang = Italian;
+} else {
+    lang = English;
+}
+
+const I18nWrapper = (props) => {
+
+    const [locale, setLocale] = React.useState(navLang);
+    const [messages, setMessages] = React.useState(lang);
+
+    function selectLang(e) {
+        const newLocale = e.target.value;
+        setLocale(newLocale);
+
+        console.log("setting msg for locale: " + newLocale);
+        
+        if (newLocale === "ja-JP") {
+            setMessages(Japanese);
+        } else if (newLocale === "it-IT") {
+            setMessages(Italian);
+        } else {
+            setMessages(English);
+        }
+    }
+
+    return (
+        <I18nContext.Provider value={{ locale, selectLang }}>
+            <IntlProvider messages={messages} locale={locale}>
+                {props.children}
+            </IntlProvider>
+        </I18nContext.Provider>
+    );
+}
+
+export default I18nWrapper;

--- a/frontend/public/locales/en-US.json
+++ b/frontend/public/locales/en-US.json
@@ -1,0 +1,8 @@
+{
+	"app.cluster.card.title": "Details",
+	"app.cluster.api.address": "Cluster API address",
+	"app.cluster.id": "Cluster ID",
+	"app.cluster.provider": "Provider",
+	"app.version": "OpenShift version",
+	"app.update.channel": "Update channel"
+}

--- a/frontend/public/locales/it-IT.json
+++ b/frontend/public/locales/it-IT.json
@@ -1,0 +1,8 @@
+{
+	"app.cluster.card.title": "Dettagli",
+	"app.cluster.api.address": "Indirizzo API del cluster",
+	"app.cluster.id": "Grappolo ID",
+	"app.cluster.provider": "Fornitrice",
+	"app.version": "OpenShift versione",
+	"app.update.channel": "Aggiorna canale"
+}

--- a/frontend/public/locales/ja-JP.json
+++ b/frontend/public/locales/ja-JP.json
@@ -1,0 +1,8 @@
+{
+	"app.cluster.card.title": "細部",
+	"app.cluster.api.address": "クラスターAPIアドレス",
+	"app.cluster.id": "クラスターID",
+	"app.cluster.provider": "プロバイダー",
+	"app.version": "OpenShiftバージョン",
+	"app.update.channel": "チャンネルを更新"
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "module": "esnext",
+    "lib": ["ESNext.Intl"],
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "outDir": "./public/dist/build/",
     "target": "es2016",
     "jsx": "react",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1107,6 +1107,39 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
 
+"@formatjs/intl-displaynames@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-displaynames/-/intl-displaynames-1.2.4.tgz#c9fffd19cd8a69bab202b2db90ded00c7b85093a"
+  integrity sha512-c9Wv/TJLrdQJvrR6NbF63ZMNHE2IVCuxwo4riVLb3YmvR6yK6dI5BT3tdLBvtg5oCY/MECx3O2UirmfQjWf1mA==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.2"
+
+"@formatjs/intl-listformat@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-1.4.4.tgz#87af681a3eadaa04387269f3e36b6f5b01c0e79a"
+  integrity sha512-b9DFftQDQEE4fVHX8WFCIXLWdlt98XPyXoyNt9wTSOhUZBJUmu97w9y8fRZnPry6pES/D9yGLJeD4/XDjG0tbw==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.2"
+
+"@formatjs/intl-relativetimeformat@^4.5.12":
+  version "4.5.12"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.12.tgz#2d2365f62c15524a40b63627cd62924f6196dd4e"
+  integrity sha512-Fh57ZnwOgAIA61i3BQhTb8C8OrCP1zDLQ35xzJ7yv/UiDDExAS8rQPf80+7Hu/8+kydL1DDgVY1PXvE63fxF+Q==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.2"
+
+"@formatjs/intl-unified-numberformat@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.3.tgz#c0006fb06588ccce614df50f3469ca2ec92816f2"
+  integrity sha512-dic7DA8REMy8gkidkCSoWqTjaLIlCyLJ5fDtlgHzK/ftwxAlbSSHkbeozZ/IKQDPbbcSppI/t9hp9KT+co/Ksg==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.2"
+
+"@formatjs/intl-utils@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.2.2.tgz#adc448035c2e3f60c550bd27c97eca336e641f5a"
+  integrity sha512-rKINaMRYH3FeNwYjEQwPtsA0kP2/hLLMB9mLi/QYfszz/huTqkInFmYilFRCX4oLlhFXDK5UQQMGNfEavN02Sg==
+
 "@fortawesome/fontawesome-common-types@^0.2.18":
   version "0.2.18"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.18.tgz#c0d8f073a5116b2de0a2c8a7aba66093a6956ce7"
@@ -2042,6 +2075,11 @@
   version "2.2.30"
   resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.30.tgz#20efa342807606ada5483731a8137cb1561e5fe9"
   integrity sha512-98fB+yo7imSD2F7PF7GIpELNgtLNgo5wjivu0W5V4jx+KVVJxo6p/qN4zdzSTBWy4/sN3pPyXwnhRSD28QX+ag==
+
+"@types/invariant@^2.2.31":
+  version "2.2.31"
+  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.31.tgz#4444c03004f215289dbca3856538434317dd28b2"
+  integrity sha512-jMlgg9pIURvy9jgBHCjQp/CyBjYHUwj91etVcDdXkFl2CwTFiQlB+8tcsMeXpXf2PFE5X2pjk4Gm43hQSMHAdA==
 
 "@types/is-function@^1.0.0":
   version "1.0.0"
@@ -8340,6 +8378,13 @@ hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   dependencies:
     react-is "^16.7.0"
 
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -8819,6 +8864,26 @@ interpret@1.2.0, interpret@^1.0.0, interpret@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+
+intl-format-cache@^4.2.24:
+  version "4.2.24"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.2.24.tgz#d6a264430553db233aa444acefc4150762d603e4"
+  integrity sha512-eea8rHu7ipmUilSd9+MCglgR07E+xJXmTYVFODmeLKsO3Psr/OrixDr6vWprz1whli7cwRdSc1/jHVBxrd+QBw==
+
+intl-messageformat-parser@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-4.1.4.tgz#98f3415e6990d44bebf2e0ad8e4cfbacf3ef5ed3"
+  integrity sha512-zV4kBUD1yhxSyaXm6bGhmP4HFH9Gh4pRQwNn+xq5P+B1dT8mpaAfU75nfUn4HgddIB6pyFnzM5MQjO55UpJwkQ==
+  dependencies:
+    "@formatjs/intl-unified-numberformat" "^3.3.3"
+
+intl-messageformat@^8.3.6:
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-8.3.6.tgz#1445e3e9b0e1befedefa86ef1a68e1ffd1a15e11"
+  integrity sha512-LUg5ObCM+E5lYzHYJ6enCwZNwxo68QBItAMbXdFYA+v6cF9YD/fD/nZlXiGY/uJ9JG7oJLiFrG9+hxbVv3PgIQ==
+  dependencies:
+    intl-format-cache "^4.2.24"
+    intl-messageformat-parser "^4.1.4"
 
 invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
@@ -13234,6 +13299,24 @@ react-inspector@^3.0.2:
     is-dom "^1.0.9"
     prop-types "^15.6.1"
 
+react-intl@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-4.4.0.tgz#c76e59214272e4b34787a581e8373f7bc19afe19"
+  integrity sha512-SId6fgh8sHTujTvOe7Epyk7X7a9nehNihR6xgdclA0RWnkovbLNCtLfa4tPojcx1xr61TgbA8RiAEiwE00LBqg==
+  dependencies:
+    "@formatjs/intl-displaynames" "^1.2.4"
+    "@formatjs/intl-listformat" "^1.4.4"
+    "@formatjs/intl-relativetimeformat" "^4.5.12"
+    "@formatjs/intl-unified-numberformat" "^3.3.3"
+    "@formatjs/intl-utils" "^2.2.2"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/invariant" "^2.2.31"
+    hoist-non-react-statics "^3.3.2"
+    intl-format-cache "^4.2.24"
+    intl-messageformat "^8.3.6"
+    intl-messageformat-parser "^4.1.4"
+    shallow-equal "^1.2.1"
+
 react-is@^16.12.0, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
@@ -14578,6 +14661,11 @@ shallow-equal@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.0.tgz#fd828d2029ff4e19569db7e19e535e94e2d1f5cc"
   integrity sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA==
+
+shallow-equal@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shallowequal@^1.0.1:
   version "1.0.2"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+# crc status; crc start
+oc login -u kubeadmin -p kKdPx-pjmWe-b3kuu-jeZm3 https://api.crc.testing:6443
+source ./contrib/oc-environment.sh
+./bin/bridge


### PR DESCRIPTION
This change is an attempt to enable [react-intl](https://github.com/formatjs/react-intl) framework and look for it's compatibility with OpenShift Console app.

ToDo:

- [ ] Identification and marking of strings for l10n
- [ ] Scripts to integrate l10n in builds, CI pipeline
- [ ] Handle sorting and filtration in l10n-ed app